### PR TITLE
Add file metadata update retry on connection error

### DIFF
--- a/2_stop_ocelot_mswindows.bat
+++ b/2_stop_ocelot_mswindows.bat
@@ -3,7 +3,7 @@ color 1F & ^
 echo ********************************************************************* & ^
 echo. & ^
 echo.   Shutting down all Ocelot services now. & ^
-echo.   If you ran this script by mistake, simple close this window now. & ^
+echo.   If you ran this script by mistake, simply close this window now. & ^
 echo. & ^
 echo.   To restart Ocelot again, run 1_start_ocelot_mswindows.bat & ^
 echo. & ^

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -110,7 +110,7 @@
                                         <h5 class="modal-title">OpacityDrive: Access and Manage Your Local Files</h5>
                                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
                                     </div>
-                                    <div class="modal-body mx-4">
+                                    <div class="modal-body mx-4" style="height:350px; overflow-y: scroll;">
                                         <form>
                                             <h6>Access Your Local OpacityDrive from a File Explorer</h6>
                                             <div class="form-group row">

--- a/tasks/opacity_api/Opacity.py
+++ b/tasks/opacity_api/Opacity.py
@@ -250,8 +250,11 @@ class Opacity:
         payload = self.signPayloadDict(metaReqDictJson)
         payloadJson = Helper.GetJson(payload)
 
-        with requests.Session() as s:
-            response = s.post(self._baseUrl + "metadata/set", data=payloadJson)
+        try:
+            with requests.Session() as s:
+                response = s.post(self._baseUrl + "metadata/set", data=payloadJson)
+        except:
+            raise
 
         return response
 


### PR DESCRIPTION
If user gets disconnected from network, keep retrying file metadata updates when uploading files.